### PR TITLE
#2 - поправил аргументы в методе get_serializer

### DIFF
--- a/sw_rest_utils/generics.py
+++ b/sw_rest_utils/generics.py
@@ -34,8 +34,8 @@ class RequestSerializerMixin:
     def get_instance(self, request):
         return None
 
-    def get_serializer(self, **params):
-        return self.request_serializer_class(**params)
+    def get_serializer(self, *args, **kwargs):
+        return self.request_serializer_class(*args, **kwargs)
 
     def validate(self):
         request = self.request


### PR DESCRIPTION
Поправил из за того, что некоторые стандартные вьюхи кидают еще и [позиционные аргументы  ](https://github.com/encode/django-rest-framework/blob/master/rest_framework/generics.py#L105)(queryset, page, etc.) и этот метод падает потому что в текущей реализации он не принимает позиционные аргументы.